### PR TITLE
Remove references to beta3 + warning

### DIFF
--- a/app/components/hero/index.js
+++ b/app/components/hero/index.js
@@ -9,7 +9,7 @@ export default class Hero extends React.Component {
                 <div className="wrapper">
                     <img src={logo} className={styles.logo} alt="Roc logo" />
                     <h2>Modern web development system</h2>
-                    <code className={styles.install}>npm install -g roc@1.0.0-beta3</code>
+                    <code className={styles.install}>npm install -g roc</code>
                 </div>
             </div>
         );

--- a/app/components/highlights/index.js
+++ b/app/components/highlights/index.js
@@ -9,11 +9,6 @@ export default class Highlights extends React.Component {
         return (
             <div className={styles.main}>
                 <div className="wrapper">
-                    <div className={styles.warning}>
-                        <img src={sign} alt="Warning" />
-                        Roc is currently in a transition period in which we are making it much better. Please use <i>beta3</i> in the meantime
-                    </div>
-
                     <h3>Highlights</h3>
                     <Highlight image="ossservice">
                         <h4>OSS as a service</h4>

--- a/docs/GETSTARTED.md
+++ b/docs/GETSTARTED.md
@@ -8,7 +8,7 @@ Make sure you have [Node.js](https://nodejs.org) 4.x or higher and [npm](https:/
 __Currently only supported in Mac and Linux.__
 
 ```
-npm install -g roc@1.0.0-beta3
+npm install -g roc
 ```
 `roc` will now be available globally on your system.
 
@@ -80,12 +80,12 @@ Roc does not enforce any set structure on you.
 
 ```
 
-`app/components` - components of the application  
+`app/components` - components of the application
 `app/screens` - components mapped to routes
-`app/redux` - source related to data flow  
-`app/routes` - react router mapping  
-`public` - files served directly from web server  
-`roc.config.js` - application configuration  
+`app/redux` - source related to data flow
+`app/routes` - react router mapping
+`public` - files served directly from web server
+`roc.config.js` - application configuration
 `package.json` - `npm` package data
 
 ## Default project configuration

--- a/docs/QUICKSTART-1.md
+++ b/docs/QUICKSTART-1.md
@@ -1,7 +1,7 @@
 #### Install
 Make sure you have node 4.x+ and npm 3.x+ on your system.
 ```
-npm install -g roc@1.0.0-beta3
+npm install -g roc
 ```
 
 #### Create redux and react project


### PR DESCRIPTION
- Removed references to beta3
- Removed warning label

We still need to update some details in docs, especially the file-tree and layout if this changes in the latest template.
